### PR TITLE
add a check for OG1 URI for appropriate variables

### DIFF
--- a/cc_plugin_og/checker.py
+++ b/cc_plugin_og/checker.py
@@ -266,8 +266,14 @@ class OGChecker(OGChecker):
             if 'https' in uri:
                 messages.append(f"variable {var_name} vocabulary {uri} contains https. Vocabulary URIs use http")
                 continue
+            if uri[-1] != '/':
+                messages.append(f"variable {var_name} vocabulary {uri} should end with a forward slash '/'")
+                continue
             if uri not in og1_uri_list:
                 messages.append(f"variable {var_name} vocabulary {uri} not found in NERC OG1 collection")
+                continue
+            if 'long_name' not in attrs:
+                messages.append(f"variable {var_name} should have attribute 'long_name'")
                 continue
             score += 1
 


### PR DESCRIPTION
This check download a list of URIs from the NERC OG1 vocabulary collection and checks that each variables with dimensions N_MEASUREMENTS with a name that does not end in `_QC` has a valid URI in the vocabulary attribute.

Also checks for long_name and checks for common misformatted URIS (using https, missing trailing slash)

Copied from https://github.com/uw-farlab/cc-plugin-og/pull/21